### PR TITLE
Remove unnecessary 'null character'

### DIFF
--- a/src/ucxh_send.c
+++ b/src/ucxh_send.c
@@ -524,7 +524,6 @@ bool ucxhPARSER_addByteArray(size_t size, const uint8_t *data)
     sprintf(atCommand+atCommandPos, "%02X", data[i]);
     atCommandPos += 2;
   }
-  atCommand[atCommandPos++] = '\0';
 
   return true;
 }


### PR DESCRIPTION
A null character ('\0') is added at the end of the Byte array in 'ucxhPARSER_addByteArray'. If multiple Byte arrays need to be added to a command, the characters after the null character are not sent.